### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -1,7 +1,7 @@
 class FurimasController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :set_furima, only: [:show, :edit, :update, :destroy]
-  before_action :move_to_index, except: [:index, :show]
+  before_action :move_to_index, only: [:edit, :update]
 
   def index
     @furimas = Furima.order(created_at: :desc)
@@ -48,7 +48,6 @@ class FurimasController < ApplicationController
 
   def move_to_index
     return if current_user.id == @furima.user_id
-
     redirect_to action: :index
   end
 

--- a/app/controllers/furimas_controller.rb
+++ b/app/controllers/furimas_controller.rb
@@ -1,6 +1,6 @@
 class FurimasController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_furima, only: [:show, :edit, :update]
+  before_action :set_furima, only: [:show, :edit, :update, :destroy]
   before_action :move_to_index, except: [:index, :show]
 
   def index
@@ -32,6 +32,11 @@ class FurimasController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @furima.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/furimas/show.html.erb
+++ b/app/views/furimas/show.html.erb
@@ -28,7 +28,7 @@
     <% if user_signed_in? && current_user.id == @furima.user_id %>
       <%= link_to "商品の編集", edit_furima_path, method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", furima_path(@furima), data: {turbo_method: :delete}, class:"item-destroy" %>
     <% elsif user_signed_in? && current_user.id != @furima.user_id %>
       <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "furimas#index"
-  resources :furimas, only: [:index, :new, :create, :show, :edit, :update]
+  resources :furimas
 end


### PR DESCRIPTION
# What
商品削除機能の実装

# Why
商品情報を削除できるようにするため

# 動作確認
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/66bf14171d215b2d8827a71e3f3939a3